### PR TITLE
fix color escape code

### DIFF
--- a/chalk/__init__.py
+++ b/chalk/__init__.py
@@ -34,7 +34,7 @@ bgs = Color(*['4%d' % i for i in range(8)])
 
 def make_code(fg, bg=None, opts=None):
     "makes the visualization escape code"
-    value = '%s;'
+    value = '%s'
     if opts and isinstance(opts, str):
         opts = (opts,)
     elif opts and not any(isinstance(opts, typo) for typo in (list, tuple)):
@@ -43,7 +43,7 @@ def make_code(fg, bg=None, opts=None):
     parts.append(value % getattr(fgs, fg))
     if bg:
         parts.append(value % getattr(bgs, bg))
-    return _esc % ''.join(parts)
+    return _esc % ';'.join(parts)
 
 
 def format_txt(fg, txt, bg, opts):

--- a/chalk/tests.py
+++ b/chalk/tests.py
@@ -30,17 +30,17 @@ class TestChalk(unittest.TestCase):
     def test_make_code_basic_use(self):
         "ensure basic functionality"
         actual = chalk.make_code('red', 'blue')
-        expected = '\x1b[31;44;m'
+        expected = '\x1b[31;44m'
         self.assertEqual(actual, expected)
 
     def test_make_code_with_opts(self):
         "ensure use of optional formats"
         actual = chalk.make_code('green', 'magenta', opts='bold')
-        expected = '\x1b[1;32;45;m'
+        expected = '\x1b[1;32;45m'
         self.assertEqual(actual, expected)
 
         actual = chalk.make_code('black', 'white', opts=('bold', 'underscore'))
-        expected = '\x1b[1;4;30;47;m'
+        expected = '\x1b[1;4;30;47m'
         self.assertEqual(actual, expected)
 
         self.assertRaises(TypeError, chalk.make_code, ('black', 'white'), {'opts': ('bold')})
@@ -48,7 +48,7 @@ class TestChalk(unittest.TestCase):
     def test_format_txt(self):
         "sometimes doc strings are useless"
         actual = chalk.format_txt('white', 'hello', 'black', None)
-        expected = "\x1b[37;40;mhello\x1b[0m\n\r"
+        expected = "\x1b[37;40mhello\x1b[0m\n\r"
         self.assertEqual(actual, expected)
 
     def test_existance_of_needed_functions(self):


### PR DESCRIPTION
The escape doesn't work for xterm and rxvt-unicode, both seem to render text in with normal mode as in `\e[0m`:

```
^[[31;mERROR^[[0m
^M^[[34;mHello world!!^[[0m
^M^[[33;mListen to me!!!^[[0m
^M^[[1;35;mThis is pretty cool^[[0m
^M^[[1;4;36;m...more stuff^[[0m
^M
```

This patch will output the following, and they does work for both xterm and rxvt-unicode:

```
^[[31mERROR^[[0m
^M^[[34mHello world!!^[[0m
^M^[[33mListen to me!!!^[[0m
^M^[[1;35mThis is pretty cool^[[0m
^M^[[1;4;36m...more stuff^[[0m
```
