### PR TITLE
Setuptools now requires configuration keys to use underscores instead of dashes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,9 @@
 Anthony Almarza <anthony.almarza@gmail.com>
 Christopher McIntyre <chrsintyre@gmail.com>
+Christopher McIntyre <chrsintyre@samson.localdomain>
+Derek Pierre <derek.pierre@gmail.com>
+Justin Holmes <justin@justinholmes.com>
 Yu-Jie Lin <livibetter@gmail.com>
+anthonyalmarza <anthony.almarza@gmail.com>
+chrsintyre <chrsintyre@gmail.com>
+derekpierre <derek.pierre@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,15 @@
 CHANGES
 =======
 
+v2.0.2
+------
+
+* Update repos so that a \`nucypher-pychalk\` package could be published to pypi
+* Update setup.cfg to use underscores instead of dashes
+* patch circle deploy filter and updates gitignore
+* Support later versions of six
+* fixes ci and readme
+* complete OOP, ci and readme refactor
 * ci changes
 * validated codecov config
 * adds codecov.yml config file
@@ -14,10 +23,6 @@ CHANGES
 * explicitly install six on travis
 * install with -e
 * conflict resolution, bumps version and adds py3 funct as proposed
-
-1.0.2
------
-
 * version bump
 * limit travis tests to 2.7
 * adds travis, updates testing utils and pep8
@@ -26,10 +31,6 @@ CHANGES
 * Tidied up format\_txt function
 * Fixed handling of byte strings when chalk run in python3. Added unicode and bytestring tests for format\_txt() function
 * Ran 2to3 over code to make it forwards compatible with python 3
-
-1.0.0
------
-
 * adds default logs and bumps version to reflect chalks use in production
 * updates nosetests instructions
 * removes stderr import

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 Chalk
 =====
 
+.. note::
+    This is a fork of `pychalk <https://github.com/anthonyalmarza/chalk>`_ to workaround an `issue with setuptools <https://github.com/anthonyalmarza/chalk/pull/23>`_.
+
 |CircleCI|
 
 |codecov|

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,12 @@
 [metadata]
-name = pychalk
+name = nucypher-pychalk
+version = 2.0.2
 author = Anthony Almarza
 author_email = anthony.almarza@gmail.com
 summary = Color printing in python
 description_file = README.rst
 description_content_type = text/x-rst; charset=UTF-8
-home_page = https://github.com/anthonyalmarza/chalk
+home_page = https://github.com/nucypher/pychalk
 license = MIT
 classifier =
     Development Status :: 4 - Beta
@@ -24,5 +25,4 @@ keywords =
     print
 
 [files]
-packages =
-    chalk
+packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = pychalk
 author = Anthony Almarza
-author-email = anthony.almarza@gmail.com
+author_email = anthony.almarza@gmail.com
 summary = Color printing in python
-description-file = README.rst
-description-content-type = text/x-rst; charset=UTF-8
-home-page = https://github.com/anthonyalmarza/chalk
+description_file = README.rst
+description_content_type = text/x-rst; charset=UTF-8
+home_page = https://github.com/anthonyalmarza/chalk
 license = MIT
 classifier =
     Development Status :: 4 - Beta


### PR DESCRIPTION
```
Collecting pychalk==2.0.1 (from nucypher==7.5.0)
  Using cached pychalk-2.0.1.tar.gz (17 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [34 lines of output]
      Traceback (most recent call last):
        File "/Users/derek/.local/share/virtualenvs/nucypher-z-zdnWw9/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
          ...
          raise InvalidConfigError(
      setuptools.errors.InvalidConfigError: Invalid dash-separated key 'author-email' in 'metadata' (setup.cfg), please use the underscore name 'author_email' instead.
      [end of output]
```